### PR TITLE
Added in new regex to handle parsing in php7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@
 ### Fixed
 - Filter unsuported tags [align, hspace, vspace, allowfullscreen, allowtransparency]
 
-
 ## 1.0.9 - 2019-12-06
 ### Fixed
 - Fixed blank image tags. Add check for blank src=""
+
+## 1.0.10 - 2020-05-27
+### Fixed
+- Updated src/vendor/trendyminds/amplify/src/lib/simple_html_dom.php with regex pattern that works with PCRE2 strict mode (php7.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,5 +38,5 @@
 - Fixed blank image tags. Add check for blank src=""
 
 ## 1.0.10 - 2020-05-27
-### Fixed
+### Updated
 - Updated src/vendor/trendyminds/amplify/src/lib/simple_html_dom.php with regex pattern that works with PCRE2 strict mode (php7.3)

--- a/src/lib/simple_html_dom.php
+++ b/src/lib/simple_html_dom.php
@@ -686,7 +686,7 @@ class simple_html_dom_node
 // This implies that an html attribute specifier may start with an @ sign that is NOT captured by the expression.
 // farther study is required to determine of this should be documented or removed.
 //		$pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
-		$pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-:]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
+		$pattern = "/([\w\-:\*]*)(?:\#([\w\-]+)|\.([\w\-]+))?(?:\[@?(!?[\w\-:]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
 		preg_match_all($pattern, trim($selector_string).' ', $matches, PREG_SET_ORDER);
 		if (is_object($debug_object)) {$debug_object->debug_log(2, "Matches Array: ", $matches);}
 
@@ -1382,7 +1382,7 @@ class simple_html_dom
 			return true;
 		}
 
-		if (!preg_match("/^[\w-:]+$/", $tag)) {
+		if (!preg_match("/^[\w\-:]+$/", $tag)) {
 			$node->_[HDOM_INFO_TEXT] = '<' . $tag . $this->copy_until('<>');
 			if ($this->char==='<') {
 				$this->link_nodes($node, false);


### PR DESCRIPTION
This updates some regex parsing in src/vendor/trendyminds/amplify/src/lib/simple_html_dom.php to work with PCRE2 strict (php7.3)
Tested locally on iuhealth.org. Working as expected.
